### PR TITLE
Standardize augmentation mutators

### DIFF
--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
@@ -49,7 +49,7 @@ import org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator.Choice;
 import org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator;
-import org.pitest.mutationtest.engine.gregor.mutators.augmentation.AODMutator;
+import org.pitest.mutationtest.engine.gregor.mutators.augmentation.ArithmeticOperandDeletion;
 import org.pitest.mutationtest.engine.gregor.mutators.augmentation.ArithmeticOperatorReplacementMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.augmentation.RelationalOperatorReplacementMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator;
@@ -220,8 +220,8 @@ public final class Mutator {
      * Augmenting mutator that replaces binary arithmetic operations
      * with their individual arguments.
      */
-    add("AOD_FIRST", new AODMutator(AODMutator.MutantType.FIRST));
-    add("AOD_LAST", new AODMutator(AODMutator.MutantType.LAST));
+    add("REMOVE_FIRST_MUTATOR", new ArithmeticOperandDeletion(ArithmeticOperandDeletion.MutantType.REMOVE_FIRST_MUTATOR));
+    add("REMOVE_LAST_MUTATOR", new ArithmeticOperandDeletion(ArithmeticOperandDeletion.MutantType.REMOVE_LAST_MUTATOR));
     addGroup("AOD", aod());
   }
 
@@ -308,7 +308,7 @@ public final class Mutator {
   }
 
   public static Collection<MethodMutatorFactory> aod() {
-    return group(new AODMutator(AODMutator.MutantType.FIRST), new AODMutator(AODMutator.MutantType.LAST));
+    return group(new ArithmeticOperandDeletion(ArithmeticOperandDeletion.MutantType.REMOVE_FIRST_MUTATOR), new ArithmeticOperandDeletion(ArithmeticOperandDeletion.MutantType.REMOVE_LAST_MUTATOR));
   }
 
   private static Comparator<? super MethodMutatorFactory> compareId() {

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/augmentation/ArithmeticOperandDeletion.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/augmentation/ArithmeticOperandDeletion.java
@@ -32,25 +32,25 @@ import org.pitest.mutationtest.engine.gregor.ZeroOperandMutation;
  * To remove the first operand, remove the operator, swap the two operands and remove the top one.
  * Because the second operand is above the first operand on the stack.
  */
-public class AODMutator implements MethodMutatorFactory {
+public class ArithmeticOperandDeletion implements MethodMutatorFactory {
 
     public enum MutantType {
 
-        FIRST, LAST;
+        REMOVE_FIRST_MUTATOR, REMOVE_LAST_MUTATOR;
     }
 
     private final MutantType mutatorType;
 
-    public AODMutator(MutantType mt) {
+    public ArithmeticOperandDeletion(MutantType mt) {
         this.mutatorType = mt;
     }
 
     @Override
     public MethodVisitor create(final MutationContext context, final MethodInfo methodInfo,
             final MethodVisitor methodVisitor) {
-        if (this.mutatorType == AODMutator.MutantType.FIRST) {
+        if (this.mutatorType == ArithmeticOperandDeletion.MutantType.REMOVE_FIRST_MUTATOR) {
             return new AODFirstMethodVisitor(this, methodInfo, context, methodVisitor);
-        } else if (this.mutatorType == AODMutator.MutantType.LAST) {
+        } else if (this.mutatorType == ArithmeticOperandDeletion.MutantType.REMOVE_LAST_MUTATOR) {
             return new AODLastMethodVisitor(this, context, methodVisitor);
         } else {
             return null;
@@ -64,7 +64,7 @@ public class AODMutator implements MethodMutatorFactory {
 
     @Override
     public String getName() {
-        return "AOD_MUTATOR - " + this.mutatorType.name();
+        return "ArithmeticOperandDeletion - " + this.mutatorType.name();
     }
 }
 
@@ -82,49 +82,49 @@ class AODFirstMethodVisitor extends AbstractInsnMutator {
 
     static {
         MUTATIONS.put(Opcodes.IADD, new InsnSubstitution(Opcodes.POP,
-                "AOD_LAST: Remove the second operand from an addition formula (int)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from an addition formula (int)"));
         MUTATIONS.put(Opcodes.DADD, new InsnSubstitution(Opcodes.POP2,
-                "AOD_LAST: Remove the second operand from an addition formula (double)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from an addition formula (double)"));
         MUTATIONS.put(Opcodes.FADD, new InsnSubstitution(Opcodes.POP,
-                "AOD_LAST: Remove the second operand from an addition formula (float)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from an addition formula (float)"));
         MUTATIONS.put(Opcodes.LADD, new InsnSubstitution(Opcodes.POP2,
-                "AOD_LAST: Remove the second operand from an addition formula (long)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from an addition formula (long)"));
 
         MUTATIONS.put(Opcodes.ISUB, new InsnSubstitution(Opcodes.POP,
-                "AOD_LAST: Remove the second operand from a subtraction formula (int)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a subtraction formula (int)"));
         MUTATIONS.put(Opcodes.DSUB, new InsnSubstitution(Opcodes.POP2,
-                "AOD_LAST: Remove the second operand from a subtraction formula (double)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a subtraction formula (double)"));
         MUTATIONS.put(Opcodes.FSUB, new InsnSubstitution(Opcodes.POP,
-                "AOD_LAST: Remove the second operand from a subtraction formula (float)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a subtraction formula (float)"));
         MUTATIONS.put(Opcodes.LSUB, new InsnSubstitution(Opcodes.POP2,
-                "AOD_LAST: Remove the second operand from a subtraction formula (long)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a subtraction formula (long)"));
 
         MUTATIONS.put(Opcodes.IMUL, new InsnSubstitution(Opcodes.POP,
-                "AOD_LAST: Remove the second operand from a multiplication formula (int)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a multiplication formula (int)"));
         MUTATIONS.put(Opcodes.DMUL, new InsnSubstitution(Opcodes.POP2,
-                "AOD_LAST: Remove the second operand from a multiplication formula (double)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a multiplication formula (double)"));
         MUTATIONS.put(Opcodes.FMUL, new InsnSubstitution(Opcodes.POP,
-                "AOD_LAST: Remove the second operand from a multiplication formula (float)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a multiplication formula (float)"));
         MUTATIONS.put(Opcodes.LMUL, new InsnSubstitution(Opcodes.POP2,
-                "AOD_LAST: Remove the second operand from a multiplication formula (long)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a multiplication formula (long)"));
 
         MUTATIONS.put(Opcodes.IDIV, new InsnSubstitution(Opcodes.POP,
-                "AOD_LAST: Remove the second operand from a division formula (int)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a division formula (int)"));
         MUTATIONS.put(Opcodes.DDIV, new InsnSubstitution(Opcodes.POP2,
-                "AOD_LAST: Remove the second operand from a division formula (double)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a division formula (double)"));
         MUTATIONS.put(Opcodes.FDIV, new InsnSubstitution(Opcodes.POP,
-                "AOD_LAST: Remove the second operand from a division formula (float)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a division formula (float)"));
         MUTATIONS.put(Opcodes.LDIV, new InsnSubstitution(Opcodes.POP2,
-                "AOD_LAST: Remove the second operand from a division formula (long)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a division formula (long)"));
 
         MUTATIONS.put(Opcodes.IREM,
-                new InsnSubstitution(Opcodes.POP, "AOD_LAST: Remove the second operand from a modulus formula (int)"));
+                new InsnSubstitution(Opcodes.POP, "REMOVE_SECOND_OPERATOR: Remove the second operand from a modulus formula (int)"));
         MUTATIONS.put(Opcodes.DREM, new InsnSubstitution(Opcodes.POP2,
-                "AOD_LAST: Remove the second operand from a modulus formula (double)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a modulus formula (double)"));
         MUTATIONS.put(Opcodes.FREM, new InsnSubstitution(Opcodes.POP,
-                "AOD_LAST: Remove the second operand from a modulus formula (float)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a modulus formula (float)"));
         MUTATIONS.put(Opcodes.LREM, new InsnSubstitution(Opcodes.POP2,
-                "AOD_LAST: Remove the second operand from a modulus formula (long)"));
+                "REMOVE_SECOND_OPERATOR: Remove the second operand from a modulus formula (long)"));
     }
 
     @Override
@@ -173,7 +173,7 @@ class AODLastMethodVisitor extends MethodVisitor {
 
     private void replaceSmallAddOperand(int opcode) {
         final MutationIdentifier muID = this.context.registerMutation(factory,
-                "AOD_MUTATOR: Remove the first operand from an addition formula");
+                "REMOVE_FIRST_OPERAND: Remove the first operand from an addition formula");
 
         if (this.context.shouldMutate(muID)) {
             removeSmallFirstOperand();
@@ -184,7 +184,7 @@ class AODLastMethodVisitor extends MethodVisitor {
 
     private void replaceSmallSubOperand(int opcode) {
         final MutationIdentifier muID = this.context.registerMutation(factory,
-                "AOD_FIRST: Remove the first operand from a subtraction formula");
+                "REMOVE_FIRST_OPERAND: Remove the first operand from a subtraction formula");
 
         if (this.context.shouldMutate(muID)) {
             removeSmallFirstOperand();
@@ -195,7 +195,7 @@ class AODLastMethodVisitor extends MethodVisitor {
 
     private void replaceSmallMulOperand(int opcode) {
         final MutationIdentifier muID = this.context.registerMutation(factory,
-                "AOD_FIRST: Remove the first operand from a multiplication formula");
+                "REMOVE_FIRST_OPERAND: Remove the first operand from a multiplication formula");
 
         if (this.context.shouldMutate(muID)) {
             removeSmallFirstOperand();
@@ -206,7 +206,7 @@ class AODLastMethodVisitor extends MethodVisitor {
 
     private void replaceSmallDivOperand(int opcode) {
         final MutationIdentifier muID = this.context.registerMutation(factory,
-                "AOD_FIRST: Remove the first operand from a division formula");
+                "REMOVE_FIRST_OPERAND: Remove the first operand from a division formula");
 
         if (this.context.shouldMutate(muID)) {
             removeSmallFirstOperand();
@@ -217,7 +217,7 @@ class AODLastMethodVisitor extends MethodVisitor {
 
     private void replaceSmallRemOperand(int opcode) {
         final MutationIdentifier muID = this.context.registerMutation(factory,
-                "AOD_FIRST: Remove the first operand from a modulus formula");
+                "REMOVE_FIRST_OPERAND: Remove the first operand from a modulus formula");
 
         if (this.context.shouldMutate(muID)) {
             removeSmallFirstOperand();
@@ -228,7 +228,7 @@ class AODLastMethodVisitor extends MethodVisitor {
 
     private void replaceLongOperand(int opcode) {
         final MutationIdentifier muID = this.context.registerMutation(factory,
-                "AOD_FIRST: Remove the first operand of from a formula involving longs");
+                "REMOVE_FIRST_OPERAND: Remove the first operand of from a formula involving longs");
 
         if (this.context.shouldMutate(muID)) {
             removeLargeFirstOperand();
@@ -239,7 +239,7 @@ class AODLastMethodVisitor extends MethodVisitor {
 
     private void replaceDoubleOperand(int opcode) {
         final MutationIdentifier muID = this.context.registerMutation(factory,
-                "AOD_FIRST: Remove the first operand of a formula involving doubles");
+                "REMOVE_FIRST_OPERAND: Remove the first operand of a formula involving doubles");
 
         if (this.context.shouldMutate(muID)) {
             removeLargeFirstOperand();

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/augmentation/ArithmeticOperatorReplacementMutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/augmentation/ArithmeticOperatorReplacementMutator.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and limitations under the License.
  */
-package org.pitest.mutationtest.engine.gregor.mutators;
+package org.pitest.mutationtest.engine.gregor.mutators.augmentation;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/augmentation/ArithmeticOperatorReplacementMutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/augmentation/ArithmeticOperatorReplacementMutator.java
@@ -28,229 +28,158 @@ import org.pitest.mutationtest.engine.gregor.ZeroOperandMutation;
 
 public enum ArithmeticOperatorReplacementMutator implements MethodMutatorFactory {
 
-  ARITHMETIC_OPERATOR_REPLACEMENT_MUTATOR;
+    ARITHMETIC_OPERATOR_REPLACEMENT_MUTATOR;
 
-  @Override
-  public MethodVisitor create(final MutationContext context,
-	      final MethodInfo methodInfo, final MethodVisitor methodVisitor) {
-    return new ArithmeticOperatorReplacementMethodVisitor(this, methodInfo, context, methodVisitor);
-  }
+    @Override
+    public MethodVisitor create(final MutationContext context, final MethodInfo methodInfo,
+            final MethodVisitor methodVisitor) {
+        return new ArithmeticOperatorReplacementMethodVisitor(this, methodInfo, context, methodVisitor);
+    }
 
-  @Override
-  public String getGloballyUniqueId() {
-    return this.getClass().getName();
-  }
+    @Override
+    public String getGloballyUniqueId() {
+        return this.getClass().getName();
+    }
 
-  @Override
-  public String getName() {
-    return name();
-  }
+    @Override
+    public String getName() {
+        return name();
+    }
 
 }
 
 class ArithmeticOperatorReplacementMethodVisitor extends AbstractInsnMutator {
 
-  private static final Map<Integer, ZeroOperandMutation> MUTATIONS   = new HashMap<>();
+    private static final Map<Integer, ZeroOperandMutation> MUTATIONS = new HashMap<>();
 
-  static {
-	  		// integers
-		    MUTATIONS.put(Opcodes.IADD, new InsnSubstitution(Opcodes.ISUB,
-		            "Replaced integer addition with subtraction"));
-		    MUTATIONS.put(Opcodes.IADD, new InsnSubstitution(Opcodes.IMUL,
-		            "Replaced integer addition with multiplication"));
-		    MUTATIONS.put(Opcodes.IADD, new InsnSubstitution(Opcodes.IDIV,
-		            "Replaced integer addition with division"));
-		    MUTATIONS.put(Opcodes.IADD, new InsnSubstitution(Opcodes.IREM,
-		            "Replaced integer addition with modulus"));
-		    
-	        MUTATIONS.put(Opcodes.ISUB, new InsnSubstitution(Opcodes.IADD,
-	            "Replaced integer subtraction with addition"));
-	        MUTATIONS.put(Opcodes.ISUB, new InsnSubstitution(Opcodes.IMUL,
-		            "Replaced integer subtraction with multiplication"));
-	        MUTATIONS.put(Opcodes.ISUB, new InsnSubstitution(Opcodes.IDIV,
-		            "Replaced integer subtraction with division"));
-	        MUTATIONS.put(Opcodes.ISUB, new InsnSubstitution(Opcodes.IREM,
-		            "Replaced integer subtraction with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.IMUL, new InsnSubstitution(Opcodes.IADD,
-	            "Replaced integer multiplication with addition"));
-	        MUTATIONS.put(Opcodes.IMUL, new InsnSubstitution(Opcodes.ISUB,
-		            "Replaced integer multiplication with subtraction"));
-	        MUTATIONS.put(Opcodes.IMUL, new InsnSubstitution(Opcodes.IDIV,
-		            "Replaced integer multiplication with division"));
-	        MUTATIONS.put(Opcodes.IMUL, new InsnSubstitution(Opcodes.IREM,
-		            "Replaced integer multiplication with modulus"));
-	        		        
-	        MUTATIONS.put(Opcodes.IDIV, new InsnSubstitution(Opcodes.IADD,
-	            "Replaced integer division with addition"));	
-	        MUTATIONS.put(Opcodes.IDIV, new InsnSubstitution(Opcodes.ISUB,
-		            "Replaced integer division with subtraction"));	
-	        MUTATIONS.put(Opcodes.IDIV, new InsnSubstitution(Opcodes.IMUL,
-		            "Replaced integer division with multiplication"));	
-	        MUTATIONS.put(Opcodes.IDIV, new InsnSubstitution(Opcodes.IREM,
-		            "Replaced integer division with modulus"));	
-	        
-	        MUTATIONS.put(Opcodes.IREM, new InsnSubstitution(Opcodes.IADD,
-	            "Replaced integer modulus with addition"));
-	        MUTATIONS.put(Opcodes.IREM, new InsnSubstitution(Opcodes.ISUB,
-		            "Replaced integer modulus with subtraction"));
-	        MUTATIONS.put(Opcodes.IREM, new InsnSubstitution(Opcodes.IMUL,
-		            "Replaced integer modulus with multiplication"));
-	        MUTATIONS.put(Opcodes.IREM, new InsnSubstitution(Opcodes.IDIV,
-		            "Replaced integer modulus with division"));
+    static {
+        // integers
+        MUTATIONS.put(Opcodes.IADD, new InsnSubstitution(Opcodes.ISUB, "Replaced integer addition with subtraction"));
+        MUTATIONS.put(Opcodes.IADD,
+                new InsnSubstitution(Opcodes.IMUL, "Replaced integer addition with multiplication"));
+        MUTATIONS.put(Opcodes.IADD, new InsnSubstitution(Opcodes.IDIV, "Replaced integer addition with division"));
+        MUTATIONS.put(Opcodes.IADD, new InsnSubstitution(Opcodes.IREM, "Replaced integer addition with modulus"));
 
+        MUTATIONS.put(Opcodes.ISUB, new InsnSubstitution(Opcodes.IADD, "Replaced integer subtraction with addition"));
+        MUTATIONS.put(Opcodes.ISUB,
+                new InsnSubstitution(Opcodes.IMUL, "Replaced integer subtraction with multiplication"));
+        MUTATIONS.put(Opcodes.ISUB, new InsnSubstitution(Opcodes.IDIV, "Replaced integer subtraction with division"));
+        MUTATIONS.put(Opcodes.ISUB, new InsnSubstitution(Opcodes.IREM, "Replaced integer subtraction with modulus"));
 
-	        // longs
+        MUTATIONS.put(Opcodes.IMUL,
+                new InsnSubstitution(Opcodes.IADD, "Replaced integer multiplication with addition"));
+        MUTATIONS.put(Opcodes.IMUL,
+                new InsnSubstitution(Opcodes.ISUB, "Replaced integer multiplication with subtraction"));
+        MUTATIONS.put(Opcodes.IMUL,
+                new InsnSubstitution(Opcodes.IDIV, "Replaced integer multiplication with division"));
+        MUTATIONS.put(Opcodes.IMUL, new InsnSubstitution(Opcodes.IREM, "Replaced integer multiplication with modulus"));
 
-	        MUTATIONS.put(Opcodes.LADD, new InsnSubstitution(Opcodes.LSUB,
-	            "Replaced long addition with subtraction"));
-	        MUTATIONS.put(Opcodes.LADD, new InsnSubstitution(Opcodes.LMUL,
-		            "Replaced long addition with multiplication"));
-	        MUTATIONS.put(Opcodes.LADD, new InsnSubstitution(Opcodes.LDIV,
-		            "Replaced long addition with division"));
-	        MUTATIONS.put(Opcodes.LADD, new InsnSubstitution(Opcodes.LREM,
-		            "Replaced long addition with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.LSUB, new InsnSubstitution(Opcodes.LADD,
-	            "Replaced long subtraction with addition"));
-	        MUTATIONS.put(Opcodes.LSUB, new InsnSubstitution(Opcodes.LMUL,
-		            "Replaced long subtraction with multiplication"));
-	        MUTATIONS.put(Opcodes.LSUB, new InsnSubstitution(Opcodes.LDIV,
-		            "Replaced long subtraction with division"));
-	        MUTATIONS.put(Opcodes.LSUB, new InsnSubstitution(Opcodes.LREM,
-		            "Replaced long subtraction with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.LMUL, new InsnSubstitution(Opcodes.LADD,
-	            "Replaced long multiplication with addition"));
-	        MUTATIONS.put(Opcodes.LMUL, new InsnSubstitution(Opcodes.LSUB,
-		            "Replaced long multiplication with subtraction"));
-	        MUTATIONS.put(Opcodes.LMUL, new InsnSubstitution(Opcodes.LDIV,
-		            "Replaced long multiplication with division"));
-	        MUTATIONS.put(Opcodes.LMUL, new InsnSubstitution(Opcodes.LREM,
-		            "Replaced long multiplication with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.LDIV, new InsnSubstitution(Opcodes.LADD,
-	            "Replaced long division with addition"));
-	        MUTATIONS.put(Opcodes.LDIV, new InsnSubstitution(Opcodes.LSUB,
-		            "Replaced long division with subtraction"));
-	        MUTATIONS.put(Opcodes.LDIV, new InsnSubstitution(Opcodes.LMUL,
-		            "Replaced long division with multiplication"));
-	        MUTATIONS.put(Opcodes.LDIV, new InsnSubstitution(Opcodes.LREM,
-		            "Replaced long division with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.LREM, new InsnSubstitution(Opcodes.LADD,
-	            "Replaced long modulus with addition"));
-	        MUTATIONS.put(Opcodes.LREM, new InsnSubstitution(Opcodes.LSUB,
-		            "Replaced long modulus with subtraction"));
-	        MUTATIONS.put(Opcodes.LREM, new InsnSubstitution(Opcodes.LMUL,
-		            "Replaced long modulus with multiplication"));
-	        MUTATIONS.put(Opcodes.LREM, new InsnSubstitution(Opcodes.LDIV,
-		            "Replaced long modulus with division"));
-	        
+        MUTATIONS.put(Opcodes.IDIV, new InsnSubstitution(Opcodes.IADD, "Replaced integer division with addition"));
+        MUTATIONS.put(Opcodes.IDIV, new InsnSubstitution(Opcodes.ISUB, "Replaced integer division with subtraction"));
+        MUTATIONS.put(Opcodes.IDIV,
+                new InsnSubstitution(Opcodes.IMUL, "Replaced integer division with multiplication"));
+        MUTATIONS.put(Opcodes.IDIV, new InsnSubstitution(Opcodes.IREM, "Replaced integer division with modulus"));
 
-	        // floats
-	        MUTATIONS.put(Opcodes.FADD, new InsnSubstitution(Opcodes.FSUB,
-	            "Replaced float addition with subtraction"));
-	        MUTATIONS.put(Opcodes.FADD, new InsnSubstitution(Opcodes.FMUL,
-		            "Replaced float addition with multiplication"));
-	        MUTATIONS.put(Opcodes.FADD, new InsnSubstitution(Opcodes.FDIV,
-		            "Replaced float addition with division"));
-	        MUTATIONS.put(Opcodes.FADD, new InsnSubstitution(Opcodes.FREM,
-		            "Replaced float addition with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.FSUB, new InsnSubstitution(Opcodes.FADD,
-	            "Replaced float subtraction with addition"));
-	        MUTATIONS.put(Opcodes.FSUB, new InsnSubstitution(Opcodes.FMUL,
-		            "Replaced float subtraction with multiplication"));
-	        MUTATIONS.put(Opcodes.FSUB, new InsnSubstitution(Opcodes.FDIV,
-		            "Replaced float subtraction with division"));
-	        MUTATIONS.put(Opcodes.FSUB, new InsnSubstitution(Opcodes.FREM,
-		            "Replaced float subtraction with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.FMUL, new InsnSubstitution(Opcodes.FADD,
-	            "Replaced float multiplication with addition"));
-	        MUTATIONS.put(Opcodes.FMUL, new InsnSubstitution(Opcodes.FSUB,
-		            "Replaced float multiplication with subtraction"));
-	        MUTATIONS.put(Opcodes.FMUL, new InsnSubstitution(Opcodes.FDIV,
-		            "Replaced float multiplication with division"));
-	        MUTATIONS.put(Opcodes.FMUL, new InsnSubstitution(Opcodes.FREM,
-		            "Replaced float multiplication with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.FDIV, new InsnSubstitution(Opcodes.FADD,
-	            "Replaced float division with addition"));
-	        MUTATIONS.put(Opcodes.FDIV, new InsnSubstitution(Opcodes.FSUB,
-		            "Replaced float division with subtraction"));
-	        MUTATIONS.put(Opcodes.FDIV, new InsnSubstitution(Opcodes.FMUL,
-		            "Replaced float division with multiplication"));
-	        MUTATIONS.put(Opcodes.FDIV, new InsnSubstitution(Opcodes.FREM,
-		            "Replaced float division with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.FREM, new InsnSubstitution(Opcodes.FADD,
-	            "Replaced float modulus with addition"));
-	        MUTATIONS.put(Opcodes.FREM, new InsnSubstitution(Opcodes.FSUB,
-		            "Replaced float modulus with subtraction"));
-	        MUTATIONS.put(Opcodes.FREM, new InsnSubstitution(Opcodes.FMUL,
-		            "Replaced float modulus with multiplication"));
-	        MUTATIONS.put(Opcodes.FREM, new InsnSubstitution(Opcodes.FDIV,
-		            "Replaced float modulus with division"));
+        MUTATIONS.put(Opcodes.IREM, new InsnSubstitution(Opcodes.IADD, "Replaced integer modulus with addition"));
+        MUTATIONS.put(Opcodes.IREM, new InsnSubstitution(Opcodes.ISUB, "Replaced integer modulus with subtraction"));
+        MUTATIONS.put(Opcodes.IREM, new InsnSubstitution(Opcodes.IMUL, "Replaced integer modulus with multiplication"));
+        MUTATIONS.put(Opcodes.IREM, new InsnSubstitution(Opcodes.IDIV, "Replaced integer modulus with division"));
 
-	        // doubles
-	        MUTATIONS.put(Opcodes.DADD, new InsnSubstitution(Opcodes.DSUB,
-	            "Replaced double addition with subtraction"));
-	        MUTATIONS.put(Opcodes.DADD, new InsnSubstitution(Opcodes.DMUL,
-		            "Replaced double addition with multiplication"));
-	        MUTATIONS.put(Opcodes.DADD, new InsnSubstitution(Opcodes.DDIV,
-		            "Replaced double addition with division"));
-	        MUTATIONS.put(Opcodes.DADD, new InsnSubstitution(Opcodes.DREM,
-		            "Replaced double addition with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.DSUB, new InsnSubstitution(Opcodes.DADD,
-	            "Replaced double subtraction with addition"));
-	        MUTATIONS.put(Opcodes.DSUB, new InsnSubstitution(Opcodes.DMUL,
-		            "Replaced double subtraction with multiplication"));
-	        MUTATIONS.put(Opcodes.DSUB, new InsnSubstitution(Opcodes.DDIV,
-		            "Replaced double subtraction with division"));
-	        MUTATIONS.put(Opcodes.DSUB, new InsnSubstitution(Opcodes.DREM,
-		            "Replaced double subtraction with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.DMUL, new InsnSubstitution(Opcodes.DADD,
-	            "Replaced double multiplication with addition"));
-	        MUTATIONS.put(Opcodes.DMUL, new InsnSubstitution(Opcodes.DSUB,
-		            "Replaced double multiplication with subtraction"));
-	        MUTATIONS.put(Opcodes.DMUL, new InsnSubstitution(Opcodes.DDIV,
-		            "Replaced double multiplication with division"));
-	        MUTATIONS.put(Opcodes.DMUL, new InsnSubstitution(Opcodes.DREM,
-		            "Replaced double multiplication with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.DDIV, new InsnSubstitution(Opcodes.DADD,
-	            "Replaced double division with addition"));
-	        MUTATIONS.put(Opcodes.DDIV, new InsnSubstitution(Opcodes.DSUB,
-		            "Replaced double division with subtraction"));
-	        MUTATIONS.put(Opcodes.DDIV, new InsnSubstitution(Opcodes.DMUL,
-		            "Replaced double division with multiplication"));
-	        MUTATIONS.put(Opcodes.DDIV, new InsnSubstitution(Opcodes.DREM,
-		            "Replaced double division with modulus"));
-	        
-	        MUTATIONS.put(Opcodes.DREM, new InsnSubstitution(Opcodes.DADD,
-	            "Replaced double modulus with addition"));
-	        MUTATIONS.put(Opcodes.DREM, new InsnSubstitution(Opcodes.DSUB,
-		            "Replaced double modulus with subtraction"));
-	        MUTATIONS.put(Opcodes.DREM, new InsnSubstitution(Opcodes.DMUL,
-		            "Replaced double modulus with multiplication"));
-	        MUTATIONS.put(Opcodes.DREM, new InsnSubstitution(Opcodes.DDIV,
-		            "Replaced double modulus with division"));
+        // longs
 
-  }
+        MUTATIONS.put(Opcodes.LADD, new InsnSubstitution(Opcodes.LSUB, "Replaced long addition with subtraction"));
+        MUTATIONS.put(Opcodes.LADD, new InsnSubstitution(Opcodes.LMUL, "Replaced long addition with multiplication"));
+        MUTATIONS.put(Opcodes.LADD, new InsnSubstitution(Opcodes.LDIV, "Replaced long addition with division"));
+        MUTATIONS.put(Opcodes.LADD, new InsnSubstitution(Opcodes.LREM, "Replaced long addition with modulus"));
 
-  ArithmeticOperatorReplacementMethodVisitor(final MethodMutatorFactory factory,
-	      final MethodInfo methodInfo, final MutationContext context,
-	      final MethodVisitor writer) {
-    super(factory, methodInfo, context, writer);
-  }
+        MUTATIONS.put(Opcodes.LSUB, new InsnSubstitution(Opcodes.LADD, "Replaced long subtraction with addition"));
+        MUTATIONS.put(Opcodes.LSUB,
+                new InsnSubstitution(Opcodes.LMUL, "Replaced long subtraction with multiplication"));
+        MUTATIONS.put(Opcodes.LSUB, new InsnSubstitution(Opcodes.LDIV, "Replaced long subtraction with division"));
+        MUTATIONS.put(Opcodes.LSUB, new InsnSubstitution(Opcodes.LREM, "Replaced long subtraction with modulus"));
 
-  @Override
-  protected Map<Integer, ZeroOperandMutation> getMutations() {
-    return MUTATIONS;
-  }
+        MUTATIONS.put(Opcodes.LMUL, new InsnSubstitution(Opcodes.LADD, "Replaced long multiplication with addition"));
+        MUTATIONS.put(Opcodes.LMUL,
+                new InsnSubstitution(Opcodes.LSUB, "Replaced long multiplication with subtraction"));
+        MUTATIONS.put(Opcodes.LMUL, new InsnSubstitution(Opcodes.LDIV, "Replaced long multiplication with division"));
+        MUTATIONS.put(Opcodes.LMUL, new InsnSubstitution(Opcodes.LREM, "Replaced long multiplication with modulus"));
+
+        MUTATIONS.put(Opcodes.LDIV, new InsnSubstitution(Opcodes.LADD, "Replaced long division with addition"));
+        MUTATIONS.put(Opcodes.LDIV, new InsnSubstitution(Opcodes.LSUB, "Replaced long division with subtraction"));
+        MUTATIONS.put(Opcodes.LDIV, new InsnSubstitution(Opcodes.LMUL, "Replaced long division with multiplication"));
+        MUTATIONS.put(Opcodes.LDIV, new InsnSubstitution(Opcodes.LREM, "Replaced long division with modulus"));
+
+        MUTATIONS.put(Opcodes.LREM, new InsnSubstitution(Opcodes.LADD, "Replaced long modulus with addition"));
+        MUTATIONS.put(Opcodes.LREM, new InsnSubstitution(Opcodes.LSUB, "Replaced long modulus with subtraction"));
+        MUTATIONS.put(Opcodes.LREM, new InsnSubstitution(Opcodes.LMUL, "Replaced long modulus with multiplication"));
+        MUTATIONS.put(Opcodes.LREM, new InsnSubstitution(Opcodes.LDIV, "Replaced long modulus with division"));
+
+        // floats
+        MUTATIONS.put(Opcodes.FADD, new InsnSubstitution(Opcodes.FSUB, "Replaced float addition with subtraction"));
+        MUTATIONS.put(Opcodes.FADD, new InsnSubstitution(Opcodes.FMUL, "Replaced float addition with multiplication"));
+        MUTATIONS.put(Opcodes.FADD, new InsnSubstitution(Opcodes.FDIV, "Replaced float addition with division"));
+        MUTATIONS.put(Opcodes.FADD, new InsnSubstitution(Opcodes.FREM, "Replaced float addition with modulus"));
+
+        MUTATIONS.put(Opcodes.FSUB, new InsnSubstitution(Opcodes.FADD, "Replaced float subtraction with addition"));
+        MUTATIONS.put(Opcodes.FSUB,
+                new InsnSubstitution(Opcodes.FMUL, "Replaced float subtraction with multiplication"));
+        MUTATIONS.put(Opcodes.FSUB, new InsnSubstitution(Opcodes.FDIV, "Replaced float subtraction with division"));
+        MUTATIONS.put(Opcodes.FSUB, new InsnSubstitution(Opcodes.FREM, "Replaced float subtraction with modulus"));
+
+        MUTATIONS.put(Opcodes.FMUL, new InsnSubstitution(Opcodes.FADD, "Replaced float multiplication with addition"));
+        MUTATIONS.put(Opcodes.FMUL,
+                new InsnSubstitution(Opcodes.FSUB, "Replaced float multiplication with subtraction"));
+        MUTATIONS.put(Opcodes.FMUL, new InsnSubstitution(Opcodes.FDIV, "Replaced float multiplication with division"));
+        MUTATIONS.put(Opcodes.FMUL, new InsnSubstitution(Opcodes.FREM, "Replaced float multiplication with modulus"));
+
+        MUTATIONS.put(Opcodes.FDIV, new InsnSubstitution(Opcodes.FADD, "Replaced float division with addition"));
+        MUTATIONS.put(Opcodes.FDIV, new InsnSubstitution(Opcodes.FSUB, "Replaced float division with subtraction"));
+        MUTATIONS.put(Opcodes.FDIV, new InsnSubstitution(Opcodes.FMUL, "Replaced float division with multiplication"));
+        MUTATIONS.put(Opcodes.FDIV, new InsnSubstitution(Opcodes.FREM, "Replaced float division with modulus"));
+
+        MUTATIONS.put(Opcodes.FREM, new InsnSubstitution(Opcodes.FADD, "Replaced float modulus with addition"));
+        MUTATIONS.put(Opcodes.FREM, new InsnSubstitution(Opcodes.FSUB, "Replaced float modulus with subtraction"));
+        MUTATIONS.put(Opcodes.FREM, new InsnSubstitution(Opcodes.FMUL, "Replaced float modulus with multiplication"));
+        MUTATIONS.put(Opcodes.FREM, new InsnSubstitution(Opcodes.FDIV, "Replaced float modulus with division"));
+
+        // doubles
+        MUTATIONS.put(Opcodes.DADD, new InsnSubstitution(Opcodes.DSUB, "Replaced double addition with subtraction"));
+        MUTATIONS.put(Opcodes.DADD, new InsnSubstitution(Opcodes.DMUL, "Replaced double addition with multiplication"));
+        MUTATIONS.put(Opcodes.DADD, new InsnSubstitution(Opcodes.DDIV, "Replaced double addition with division"));
+        MUTATIONS.put(Opcodes.DADD, new InsnSubstitution(Opcodes.DREM, "Replaced double addition with modulus"));
+
+        MUTATIONS.put(Opcodes.DSUB, new InsnSubstitution(Opcodes.DADD, "Replaced double subtraction with addition"));
+        MUTATIONS.put(Opcodes.DSUB,
+                new InsnSubstitution(Opcodes.DMUL, "Replaced double subtraction with multiplication"));
+        MUTATIONS.put(Opcodes.DSUB, new InsnSubstitution(Opcodes.DDIV, "Replaced double subtraction with division"));
+        MUTATIONS.put(Opcodes.DSUB, new InsnSubstitution(Opcodes.DREM, "Replaced double subtraction with modulus"));
+
+        MUTATIONS.put(Opcodes.DMUL, new InsnSubstitution(Opcodes.DADD, "Replaced double multiplication with addition"));
+        MUTATIONS.put(Opcodes.DMUL,
+                new InsnSubstitution(Opcodes.DSUB, "Replaced double multiplication with subtraction"));
+        MUTATIONS.put(Opcodes.DMUL, new InsnSubstitution(Opcodes.DDIV, "Replaced double multiplication with division"));
+        MUTATIONS.put(Opcodes.DMUL, new InsnSubstitution(Opcodes.DREM, "Replaced double multiplication with modulus"));
+
+        MUTATIONS.put(Opcodes.DDIV, new InsnSubstitution(Opcodes.DADD, "Replaced double division with addition"));
+        MUTATIONS.put(Opcodes.DDIV, new InsnSubstitution(Opcodes.DSUB, "Replaced double division with subtraction"));
+        MUTATIONS.put(Opcodes.DDIV, new InsnSubstitution(Opcodes.DMUL, "Replaced double division with multiplication"));
+        MUTATIONS.put(Opcodes.DDIV, new InsnSubstitution(Opcodes.DREM, "Replaced double division with modulus"));
+
+        MUTATIONS.put(Opcodes.DREM, new InsnSubstitution(Opcodes.DADD, "Replaced double modulus with addition"));
+        MUTATIONS.put(Opcodes.DREM, new InsnSubstitution(Opcodes.DSUB, "Replaced double modulus with subtraction"));
+        MUTATIONS.put(Opcodes.DREM, new InsnSubstitution(Opcodes.DMUL, "Replaced double modulus with multiplication"));
+        MUTATIONS.put(Opcodes.DREM, new InsnSubstitution(Opcodes.DDIV, "Replaced double modulus with division"));
+
+    }
+
+    ArithmeticOperatorReplacementMethodVisitor(final MethodMutatorFactory factory, final MethodInfo methodInfo,
+            final MutationContext context, final MethodVisitor writer) {
+        super(factory, methodInfo, context, writer);
+    }
+
+    @Override
+    protected Map<Integer, ZeroOperandMutation> getMutations() {
+        return MUTATIONS;
+    }
 
 }

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/GregorMutationEngineTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/GregorMutationEngineTest.java
@@ -28,20 +28,18 @@ import org.pitest.mutationtest.engine.gregor.mutators.MathMutator;
 
 public class GregorMutationEngineTest {
 
-  private GregorMutationEngine testee;
+    private GregorMutationEngine testee;
 
-  @Test
-  public void shouldReportNamesOfSuppliedMutators() {
-    final Collection<MethodMutatorFactory> mutators = Mutator
-        .fromStrings(Arrays.asList("CONDITIONALS_BOUNDARY", "MATH","ARITHMETIC_OPERATOR_REPLACEMENT_MUTATOR"));
-    final DefaultMutationEngineConfiguration config = new DefaultMutationEngineConfiguration(
-        i -> true, mutators);
-    this.testee = new GregorMutationEngine(config);
-    assertEquals(Arrays.asList(
-        ConditionalsBoundaryMutator.CONDITIONALS_BOUNDARY_MUTATOR.getName(),
-        ArithmeticOperatorReplacementMutator.ARITHMETIC_OPERATOR_REPLACEMENT_MUTATOR.getName(),
-        MathMutator.MATH_MUTATOR.getName()), this.testee.getMutatorNames());
+    @Test
+    public void shouldReportNamesOfSuppliedMutators() {
+        final Collection<MethodMutatorFactory> mutators = Mutator
+                .fromStrings(Arrays.asList("CONDITIONALS_BOUNDARY", "MATH", "ARITHMETIC_OPERATOR_REPLACEMENT_MUTATOR"));
+        final DefaultMutationEngineConfiguration config = new DefaultMutationEngineConfiguration(i -> true, mutators);
+        this.testee = new GregorMutationEngine(config);
+        assertEquals(Arrays.asList(ConditionalsBoundaryMutator.CONDITIONALS_BOUNDARY_MUTATOR.getName(),
+                ArithmeticOperatorReplacementMutator.ARITHMETIC_OPERATOR_REPLACEMENT_MUTATOR.getName(),
+                MathMutator.MATH_MUTATOR.getName()), this.testee.getMutatorNames());
 
-  }
+    }
 
 }

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/GregorMutationEngineTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/GregorMutationEngineTest.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.gregor.config.DefaultMutationEngineConfiguration;
 import org.pitest.mutationtest.engine.gregor.config.Mutator;
-import org.pitest.mutationtest.engine.gregor.mutators.ArithmeticOperatorReplacementMutator;
+import org.pitest.mutationtest.engine.gregor.mutators.augmentation.ArithmeticOperatorReplacementMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.ConditionalsBoundaryMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.MathMutator;
 


### PR DESCRIPTION
This fixes the checkstyle errors with AOR and standardizes the naming of the three augmentation mutators.
It is intended to supercede PR #11.